### PR TITLE
Fix for Issue #2: Add code to eat the UnsupportedVersionException for brokers that don'…

### DIFF
--- a/service/libraries/kafkaCommon/src/main/java/com/event/discovery/agent/kafkaCommon/KafkaCommon.java
+++ b/service/libraries/kafkaCommon/src/main/java/com/event/discovery/agent/kafkaCommon/KafkaCommon.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
@@ -400,6 +401,8 @@ public class KafkaCommon {
                 log.info("No Authorizer is configured on the broker");
             } else if (e.getCause() instanceof ClusterAuthorizationException) {
                 log.info("User '" + brokerAuthentication.getAdminUsername() + "' is not authorized to discover ACLs");
+            } else if (e.getCause() instanceof UnsupportedVersionException) {
+                log.info("Ignoring ACLs." + e.getMessage());
             } else {
                 throw e;
             }

--- a/service/services/eventDiscoveryService/install/offline/awsmsk/build.sh
+++ b/service/services/eventDiscoveryService/install/offline/awsmsk/build.sh
@@ -1,3 +1,3 @@
-cp ../../../target/event-discovery-agent-1.0-SNAPSHOT.jar .
-docker build --build-arg JAR_FILE=event-discovery-agent-1.0-SNAPSHOT.jar --tag event-discovery-agent:1.0 .
-rm ./event-discovery-agent-1.0-SNAPSHOT.jar
+cp ../../../target/event-discovery-agent-app-1.0-SNAPSHOT.jar .
+docker build --build-arg JAR_FILE=event-discovery-agent-app-1.0-SNAPSHOT.jar --build-arg AGENT_VERSION=1.0.0 --tag async-api-tool:1.0 .
+rm ./event-discovery-agent-app-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Fix for Issue #2: Add code to eat the UnsupportedVersionException for brokers that don't support ACL queries.

The discovery tool was already eating other exception types so just added the UnsupportedVersionException to the list since we want to scan to succeed even if the particular broker does not support the ACL query.