### PR TITLE
DATAGO-64225: Update readme to disambiguate from Event Portal 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Image of telescope](./docs/img/discovery.png)
 
-# Event Discovery Agent
+# Event Discovery Agent for Event Portal 1.0
+
+[Click here for Event Portal 2.0 Event Management Agent](https://github.com/SolaceProducts/event-management-agent)
 
 Discover event streams flowing through a broker.
 


### PR DESCRIPTION
Updated the readme to make it clear that this agent was developed for Event Portal 1.0 and provided a link for the agent for Event Portal 2.0.